### PR TITLE
Allowing the Association of Any L1 Safe Account in SafeRemoteKeystoreModule

### DIFF
--- a/packages/safe-scroll-keystore/contracts/SafeRemoteKeystoreModule.sol
+++ b/packages/safe-scroll-keystore/contracts/SafeRemoteKeystoreModule.sol
@@ -269,7 +269,7 @@ contract SafeRemoteKeystoreModule is Initializable {
 
                 checkSignatures(dataHash, contractSignature, currentOwner);
             } else if (v == 1) {
-                // TODO: remove, no need to check approved hash on L1 of txs that happen on L2
+                // TODO: this branch can be removed, because no one will approve L2's tx on L1
                 // If v is 1 then it is an approved hash
                 // When handling approved hashes the address of the approver is encoded into r
                 currentOwner = address(uint160(uint256(r)));
@@ -287,7 +287,7 @@ contract SafeRemoteKeystoreModule is Initializable {
             } else if (v > 30) {
                 currentOwner = ECDSA.recover(
                     MessageHashUtils.toEthSignedMessageHash(dataHash),
-                    v,
+                    v - 4,
                     r,
                     s
                 );
@@ -298,7 +298,7 @@ contract SafeRemoteKeystoreModule is Initializable {
 
                 if (!found) revert InvalidSignature();
             } else {
-                currentOwner = ecrecover(dataHash, uint8(v), r, s);
+                currentOwner = ecrecover(dataHash, v, r, s);
                 bool found = false;
                 for (uint256 j = 0; j < owners.length; j++)
                     if (currentOwner == owners[j]) found = true;

--- a/packages/safe-scroll-keystore/contracts/SafeRemoteKeystoreModule.sol
+++ b/packages/safe-scroll-keystore/contracts/SafeRemoteKeystoreModule.sol
@@ -268,6 +268,8 @@ contract SafeRemoteKeystoreModule is Initializable {
                     threshold,
                     innerOwners
                 );
+            } else if (v == 1){
+                // todo: add v = 1, l1sload the approveHash
             } else if (v > 30) {
                 currentOwner = ECDSA.recover(
                     MessageHashUtils.toEthSignedMessageHash(dataHash),
@@ -281,8 +283,6 @@ contract SafeRemoteKeystoreModule is Initializable {
                     if (currentOwner == owners[j]) found = true;
 
                 if (!found) revert InvalidSignature();
-            } else if ( v == 1 ){
-            // todo: add v = 1, l1sload the approveHash
             } else {
                 currentOwner = ecrecover(dataHash, uint8(v), r, s);
                 bool found = false;

--- a/packages/safe-scroll-keystore/contracts/SafeRemoteKeystoreModule.sol
+++ b/packages/safe-scroll-keystore/contracts/SafeRemoteKeystoreModule.sol
@@ -210,15 +210,15 @@ contract SafeRemoteKeystoreModule is Initializable {
         bytes memory signatures,
         uint256 requiredSignatures,
         address[] memory owners
-    ) internal pure {
+    ) internal view {
         // Check that the provided signature data is not too short
         if (signatures.length < requiredSignatures * 65)
             revert InvalidSignatureCount();
 
         for (uint256 i = 0; i < requiredSignatures; i++) {
             (uint8 v, bytes32 r, bytes32 s) = signatureSplit(signatures, i);
-
-            if (v = 0) {
+            address currentOwner;
+            if (v == 0) {
                 // require(keccak256(data) == dataHash, "GS027");
                 // If v is 0 then it is a contract signature
                 // When handling contract signatures the address of the contract is encoded into r
@@ -227,10 +227,10 @@ contract SafeRemoteKeystoreModule is Initializable {
                 // Check that signature data pointer (s) is not pointing inside the static part of the signatures bytes
                 // This check is not completely accurate, since it is possible that more signatures than the threshold are send.
                 // Here we only check that the pointer is not pointing inside the part that is being processed
-                require(uint256(s) >= requiredSignatures.mul(65), "GS021");
+                require(uint256(s) >= requiredSignatures * 65, "GS021");
 
                 // Check that signature data pointer (s) is in bounds (points to the length of data -> 32 bytes)
-                require(uint256(s).add(32) <= signatures.length, "GS022");
+                require(uint256(s) + 32 <= signatures.length, "GS022");
 
                 // Check if the contract signature is in bounds: start of data is s + 32 and end is start + signature length
                 uint256 contractSignatureLen;
@@ -239,7 +239,7 @@ contract SafeRemoteKeystoreModule is Initializable {
                     contractSignatureLen := mload(add(add(signatures, s), 0x20))
                 }
                 require(
-                    uint256(s).add(32).add(contractSignatureLen) <=
+                    uint256(s) + 32 + contractSignatureLen <=
                         signatures.length,
                     "GS023"
                 );
@@ -269,7 +269,7 @@ contract SafeRemoteKeystoreModule is Initializable {
                     innerOwners
                 );
             } else if (v > 30) {
-                address currentOwner = ECDSA.recover(
+                currentOwner = ECDSA.recover(
                     MessageHashUtils.toEthSignedMessageHash(dataHash),
                     v,
                     r,
@@ -281,9 +281,16 @@ contract SafeRemoteKeystoreModule is Initializable {
                     if (currentOwner == owners[j]) found = true;
 
                 if (!found) revert InvalidSignature();
-            }
+            } else if ( v == 1 ){
+            // todo: add v = 1, l1sload the approveHash
+            } else {
+                currentOwner = ecrecover(dataHash, uint8(v), r, s);
+                bool found = false;
+                for (uint256 j = 0; j < owners.length; j++)
+                    if (currentOwner == owners[j]) found = true;
 
-            // todo: add v = 1
+                if (!found) revert InvalidSignature();
+            }
         }
     }
 

--- a/packages/safe-scroll-keystore/test/SafeRemoteKeystoreModule.spec.ts
+++ b/packages/safe-scroll-keystore/test/SafeRemoteKeystoreModule.spec.ts
@@ -2,7 +2,7 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import { expect } from 'chai'
 import { JsonRpcProvider, parseEther } from 'ethers'
 
-import { execKeystoreTransaction, execKeystoreTransactionNested} from './helpers/execKeystoreTransaction'
+import execKeystoreTransaction, { execKeystoreTransactionNested } from './helpers/execKeystoreTransaction'
 import execTransaction from './helpers/execSafeTransaction'
 import setup, { nestedSetup } from './helpers/setup'
 import { HardhatEthersProvider } from '@nomicfoundation/hardhat-ethers/internal/hardhat-ethers-provider'

--- a/packages/safe-scroll-keystore/test/SafeRemoteKeystoreModule.spec.ts
+++ b/packages/safe-scroll-keystore/test/SafeRemoteKeystoreModule.spec.ts
@@ -127,7 +127,7 @@ describe('SafeRemoteKeystoreModule', () => {
     })
 
     it('Executes ETH transfer via SafeRemoteKeystore module with Nested Contract Signature', async () => {
-        const { provider, safeL1, safeNestedL1, safeL2, safeRemoteKeystoreModule, owner1L1, owner2L1, ownerL2 } = await loadFixture(nestedSetup)
+        const { provider, safeNestedL1, safeL1, safeL2, safeRemoteKeystoreModule, owner1L1, owner2L1, ownerL2 } = await loadFixture(nestedSetup)
 
         const safeL2Address = await safeL2.getAddress()
         const safeRemoteKeystoreModuleAddress = await safeRemoteKeystoreModule.getAddress()
@@ -142,7 +142,7 @@ describe('SafeRemoteKeystoreModule', () => {
         const amount = parseEther("0.1")
         await execKeystoreTransactionNested(safeRemoteKeystoreModule, {
             safeL2: safeL2Address,
-            safeNestedL1: safeNestedL1,
+            safeL1: safeL1,
             to: RECIPIENT_ADDR,
             value: amount,
             data: "0x",

--- a/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
+++ b/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
@@ -1,7 +1,11 @@
 import { concat, getBytes, solidityPackedKeccak256 } from 'ethers'
 import { SafeRemoteKeystoreModule } from '../../typechain-types'
+import { sign } from 'crypto';
+const CONTRACT_ADDR_PREFIX = "0x000000000000000000000000";
+const CONTRACT_SIG_V = "0x00";
+const CONTRACT_SIG_OFFSET = "0x0000000000000000000000000000000000000000000000000000000000000082";
 
-export default async function execKeystoreTransaction(
+export async function execKeystoreTransaction(
   module: SafeRemoteKeystoreModule,
   {
     safeL2,
@@ -16,10 +20,11 @@ export default async function execKeystoreTransaction(
   const msg = await module.getTxHash(safeL2, to, value, data, operation)
 
   // Sign message with signers L1
-  const signatures = []
+  const signatures: string[] = []
   for (var signer of signersL1) {
-    const signature = await signer.signMessage(getBytes(msg))
-    signatures.push(signature)
+    let signature = await signer.signMessage(getBytes(msg));
+    signatures.push(updateEIP191Sig(signature)) 
+
   }
 
   // Execute transaction
@@ -32,4 +37,66 @@ export default async function execKeystoreTransaction(
     operation,
     concat(signatures)
   )
+}
+
+export async function execKeystoreTransactionNested(
+  module: SafeRemoteKeystoreModule,
+  {
+    safeL2,
+    safeNestedL1,
+    to,
+    value,
+    data,
+    operation,
+    signersL1
+  }: any
+) {
+  // Get message
+  const msg = await module.getTxHash(safeL2, to, value, data, operation)
+
+  // Sign message with signers L1
+  const signatures: string[] = []
+  const signature_owner1 = await signersL1[0].signMessage(getBytes(msg));
+
+  // First we need the signersL1[0] -- owner1L1, to sign the tx, the owner1L1 is the EOA member of SAFE_L1
+  signatures.push(updateEIP191Sig(signature_owner1));
+
+  // Then, we will construct the contract sig for safeNestedL1
+  signatures.push(CONTRACT_ADDR_PREFIX, safeNestedL1);
+  signatures.push(CONTRACT_SIG_OFFSET, CONTRACT_SIG_V);
+  
+  // Set the offset for the following 2 signature
+  signatures.push(CONTRACT_SIG_OFFSET);
+
+  // concat with the sig by owner1L1 & owner2L1
+  for (var signer of signersL1) {
+    let signature = await signer.signMessage(getBytes(msg));
+    signatures.push(updateEIP191Sig(signature))   
+  }
+
+  console.log(signatures)
+  // Execute transaction
+  console.log(`---> SafeKeystoreModule.executeTransaction :: to=${to}, value=${value}, data=${data}, operation=${operation}, signatures=${concat(signatures)}`)
+  return module.executeTransaction(
+    safeL2,
+    to,
+    value,
+    data,
+    operation,
+    concat(signatures)
+  )
+}
+
+function updateEIP191Sig(
+  signature: string
+) {
+  const lastByte = signature.slice(-2);
+  // Since it is a eip191 sig
+  if (lastByte === "1b" || lastByte === "1c") {
+    const modifiedByte = (parseInt(lastByte, 16) + 4).toString(16);
+    signature = signature.slice(0, -2) + modifiedByte.padStart(2, "0");
+    return signature
+  } else {
+    throw new Error("Last byte is not 1b or 1c");
+  }
 }

--- a/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
+++ b/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
@@ -43,7 +43,7 @@ export async function execKeystoreTransactionNested(
   module: SafeRemoteKeystoreModule,
   {
     safeL2,
-    safeNestedL1,
+    safeL1,
     to,
     value,
     data,
@@ -62,7 +62,7 @@ export async function execKeystoreTransactionNested(
   signatures.push(updateEIP191Sig(signature_owner1));
 
   // Then, we will construct the contract sig for safeNestedL1
-  signatures.push(CONTRACT_ADDR_PREFIX, safeNestedL1);
+  signatures.push(CONTRACT_ADDR_PREFIX, safeL1);
   signatures.push(CONTRACT_SIG_OFFSET, CONTRACT_SIG_V);
   
   // Set the offset for the following 2 signature

--- a/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
+++ b/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
@@ -5,7 +5,7 @@ const CONTRACT_ADDR_PREFIX = "0x000000000000000000000000";
 const CONTRACT_SIG_V = "0x00";
 const CONTRACT_SIG_OFFSET = "0x0000000000000000000000000000000000000000000000000000000000000082";
 
-export async function execKeystoreTransaction(
+export default async function execKeystoreTransaction(
   module: SafeRemoteKeystoreModule,
   {
     safeL2,

--- a/packages/safe-scroll-keystore/test/helpers/setup.ts
+++ b/packages/safe-scroll-keystore/test/helpers/setup.ts
@@ -93,7 +93,10 @@ export default async function setup() {
   }
 }
 
-
+/// We are going to set a nested multisig account structure on L1:
+/// The multisig account `SAFE_L1` has 2 owners : `owner1L1`(which is a EOA) and `safeNestedL1`(which is another multisig account)
+/// The multisig account `SafeNestedL1` has 2 owners: `owner1L1` and `owner2L1`(which are both EOAs)
+/// Both of the 2 multisig accounts(`SAFE_L1` & `SafeNestedL1`) have a threshold of 2
 export async function nestedSetup() {
   const [owner1L1, owner2L1, ownerL2, deployer, relayer] = await hre.ethers.getSigners()
   const thresholdL1 = "0x02" // 2

--- a/packages/safe-scroll-keystore/test/helpers/setup.ts
+++ b/packages/safe-scroll-keystore/test/helpers/setup.ts
@@ -17,7 +17,7 @@ import { AbiCoder, getBytes, hexlify, keccak256, parseEther, toUtf8Bytes, zeroPa
 
 
 const SAFE_L1 = "0x0000000000000000000000000000000000005aFE"
-
+const SAFE_NESTED_L1 = "0x0000000000000000000000000000000000006bEF"
 export default async function setup() {
   const [owner1L1, owner2L1, ownerL2, deployer, relayer] = await hre.ethers.getSigners()
   const thresholdL1 = "0x02" // 2
@@ -79,6 +79,98 @@ export default async function setup() {
     provider: owner1L1.provider,
     // safes
     safeL1: SAFE_L1,
+    safeL2,
+    // singletons
+    safeRemoteKeystoreModule,
+    safeDisableLocalKeystoreGuard,
+    l1sload,
+    // ERC20 token
+    token,
+    // signers
+    owner1L1,
+    owner2L1,
+    ownerL2
+  }
+}
+
+
+export async function nestedSetup() {
+  const [owner1L1, owner2L1, ownerL2, deployer, relayer] = await hre.ethers.getSigners()
+  const thresholdL1 = "0x02" // 2
+  const thresholdL2 = "0x01"
+
+  const { safeProxyFactoryAddress, safeMastercopyAddress } = await deploySingletons(deployer)
+
+  // Create Safe
+  const safeL2Address = await deploySafeProxy(safeProxyFactoryAddress, safeMastercopyAddress, [ownerL2.address], thresholdL2, deployer)
+
+  // Deploy Test/Mocks contracts
+  const l1Blocks = await deployMockedL1Blocks(deployer)
+  const l1sload = await deployMockedL1Sload(deployer)
+  const token = await deployTestToken(deployer)
+
+  // Configure Mocks
+  const abiencoder = AbiCoder.defaultAbiCoder()
+  const SENTINEL_ADDR = "0x0000000000000000000000000000000000000001"
+  await l1sload.set(SAFE_L1, zeroPadValue("0x04", 32), zeroPadValue(thresholdL1, 32));
+  await l1sload.set(
+    SAFE_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [SENTINEL_ADDR, zeroPadValue("0x02", 32)])),
+    zeroPadValue(owner1L1.address, 32));
+  await l1sload.set(
+    SAFE_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [owner1L1.address, zeroPadValue("0x02", 32)])),
+    zeroPadValue(SAFE_NESTED_L1, 32));
+  await l1sload.set(
+    SAFE_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [SAFE_NESTED_L1, zeroPadValue("0x02", 32)])),
+    zeroPadValue(SENTINEL_ADDR, 32));
+  // set the nested L1
+  await l1sload.set(SAFE_NESTED_L1, zeroPadValue("0x04", 32), zeroPadValue(thresholdL1, 32));
+  await l1sload.set(
+    SAFE_NESTED_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [SENTINEL_ADDR, zeroPadValue("0x02", 32)])),
+    zeroPadValue(owner1L1.address, 32));
+  await l1sload.set(
+    SAFE_NESTED_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [owner1L1.address, zeroPadValue("0x02", 32)])),
+    zeroPadValue(owner2L1.address, 32));
+  await l1sload.set(
+    SAFE_NESTED_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [owner2L1.address, zeroPadValue("0x02", 32)])),
+    zeroPadValue(SENTINEL_ADDR, 32));
+  
+
+  // Deploy Keystore module
+  const SafeRemoteKeystoreModuleContract = await ethers.getContractFactory("SafeRemoteKeystoreModule");
+  const safeRemoteKeystoreModule = await SafeRemoteKeystoreModuleContract.deploy();
+
+  // Deploy Keystore guard
+  const SafeDisableLocalKeystoreGuardContract = await ethers.getContractFactory("SafeDisableLocalKeystoreGuard");
+  const safeDisableLocalKeystoreGuard = await SafeDisableLocalKeystoreGuardContract.deploy(safeRemoteKeystoreModule);
+
+  // Configure Keystore module
+  await safeRemoteKeystoreModule.initialize(l1Blocks, l1sload, safeDisableLocalKeystoreGuard)
+
+  // Connect Safe
+  //const safeL1 = ISafe__factory.connect(safeL1Address, relayer)
+  const safeL2 = ISafe__factory.connect(safeL2Address, relayer)
+
+  // fund the safe (1 ETH)
+  await ownerL2.sendTransaction({
+    to: safeL2Address,
+    value: parseEther('1'),
+  })
+
+  // fund the safe (1000 TT)
+  await token.transfer(safeL2Address, 1000)
+
+  return {
+    //provider
+    provider: owner1L1.provider,
+    // safes
+    safeL1: SAFE_L1,
+    safeNestedL1: SAFE_NESTED_L1,
     safeL2,
     // singletons
     safeRemoteKeystoreModule,


### PR DESCRIPTION
We understand that the current implementation of SafeRemoteKeystoreModule is still in the PoC (proof of concept) stage, so many cases may not yet be considered. However, we still aim to make SafeRemoteKeystoreModule more complete.

## Problem Statement
We found that based on the current implementation of checkSignatures in the SafeRemoteKeystoreModule, only regular Safe addresses from L1 can be associated within the module. Specifically, this means that the Safe account must have all its owners as EOA (Externally Owned Accounts). If the user happens to associate an L1 nested multisig account, the SafeRemoteKeystoreModule will trigger an error.

## Improvement Approach
We have modified the `checkSignatures` implementation to add support for Contract Signature verification. This allows users to associate any L1 Safe account through the SafeRemoteKeystoreModule, making the Safe-Scroll-Keystore solution more robust and product-ready.

## Testing Process
[This article](https://hackmd.io/yS0HqYs3RgGFyExflj91zA?view) explains in detail how to associate an L1 nested multisig account in the `SafeRemoteKeystoreModule` and successfully send a transaction.

## Remaining Issues
As noted, we introduced a new status check for `ApprovedHash`, which requires the user to send an approveHash transaction on L1 for the L2 transaction. From a practical standpoint, this is almost infeasible due to the high gas fees on L1. We can continue to discuss possible solutions to address this in the future.